### PR TITLE
Add the ability to set the ident string on the fly

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -105,6 +105,11 @@ class Syslogger
     @level = level
   end
 
+  # Sets the ident string passed along to Syslog
+  def ident=(ident)
+    @ident = ident
+  end
+
   protected
 
   # Borrowed from SyslogLogger.

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -175,6 +175,19 @@ describe "Syslogger" do
     end
   end # describe "level="
 
+  describe "ident=" do
+    before(:each) do
+      @logger = Syslogger.new("my_app", Syslog::LOG_PID | Syslog::LOG_CONS, nil)
+    end
+
+    it "should permanently change the ident string" do
+      @logger.ident = "new_ident"
+      Syslog.should_receive(:open).with("new_ident", Syslog::LOG_PID | Syslog::LOG_CONS, nil).and_yield(syslog=mock("syslog", :mask= => true))
+      syslog.should_receive(:log)
+      @logger.warn("should get the new ident string")
+    end
+  end
+
   describe ":level? methods" do
     before(:each) do
       @logger = Syslogger.new("my_app", Syslog::LOG_PID, Syslog::LOG_USER)


### PR DESCRIPTION
I'm using this in resque and figured it may be of general interest.  Thanks for this gem btw, much better than SyslogLogger.
