### PR TITLE
Use default program name if message passed in progname argument.

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -81,7 +81,11 @@ class Syslogger
   #             If both are nil or no block is given, it will use the progname as per the behaviour of both the standard Ruby logger, and the Rails BufferedLogger.
   # +progname+:: optionally, overwrite the program name that appears in the log message.
   def add(severity, message = nil, progname = nil, &block)
+    if message.nil? && block.nil? && !progname.nil? 
+      message, progname = progname, nil 
+    end
     progname ||= @ident
+
     @mutex.synchronize do
       Syslog.open(progname, @options, @facility) do |s|
         s.mask = Syslog::LOG_UPTO(MAPPING[@level])

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -103,6 +103,24 @@ describe "Syslogger" do
       @logger.add(Logger::INFO, "message", "progname") { "my message" }
     end
 
+    it "should use the default progname when message is passed in progname" do
+      Syslog.should_receive(:open).
+        with("my_app", Syslog::LOG_PID, Syslog::LOG_USER).
+        and_yield(syslog = mock("syslog", :mask= => true))
+
+      syslog.should_receive(:log).with(Syslog::LOG_INFO, "message")
+      @logger.add(Logger::INFO, nil, "message")
+    end
+
+    it "should use the given progname if message is passed in block" do
+      Syslog.should_receive(:open).
+        with("progname", Syslog::LOG_PID, Syslog::LOG_USER).
+        and_yield(syslog = mock("syslog", :mask= => true))
+
+      syslog.should_receive(:log).with(Syslog::LOG_INFO, "message")
+      @logger.add(Logger::INFO, nil, "progname") { "message" }
+    end
+
     it "should substitute '%' for '%%' before adding the :message" do
       Syslog.stub(:open).and_yield(syslog=mock("syslog", :mask= => true))
       syslog.should_receive(:log).with(Syslog::LOG_INFO, "%%me%%ssage%%")


### PR DESCRIPTION
Currently the Syslog entry gets a clobbered progname as Rails' and other loggers often send `message` in `progname`.
