### PR TITLE
Log an empty string if both message and block are nil.

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -85,7 +85,7 @@ class Syslogger
     @mutex.synchronize do
       Syslog.open(progname, @options, @facility) do |s|
         s.mask = Syslog::LOG_UPTO(MAPPING[@level])
-        communication = clean(message || (block && block.call) || progname)
+        communication = clean(message || block && block.call)
         if self.max_octets
           buffer = ""
           communication.bytes do |byte|

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -119,17 +119,17 @@ describe "Syslogger" do
       Syslog.should_receive(:open).
         with("my_app", Syslog::LOG_PID, Syslog::LOG_USER).
         and_yield(syslog=mock("syslog", :mask= => true))
-      syslog.should_receive(:log).with(Syslog::LOG_INFO, "my_app")
+      syslog.should_receive(:log).with(Syslog::LOG_INFO, "")
       lambda {
         @logger.add(Logger::INFO, nil)
       }.should_not raise_error
     end
 
-    it "should use given progname as the message if the message and block are nil" do
+    it "should send an empty string if the message and block are nil" do
       Syslog.should_receive(:open).
         with("my_app", Syslog::LOG_PID, Syslog::LOG_USER).
         and_yield(syslog=mock("syslog", :mask= => true))
-      syslog.should_receive(:log).with(Syslog::LOG_INFO, "my_app")
+      syslog.should_receive(:log).with(Syslog::LOG_INFO, "")
       @logger.add(Logger::INFO, nil)
     end
 


### PR DESCRIPTION
This changes the behavior that #5 wished for to make it more consistent and reasonable. Ruby's `Logger` et al. log either the word "nil" or an empty string when given nothing, not the app name.
