### PR TITLE
Added a simple formatter to make it work for Rails 4

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -6,7 +6,7 @@ class Syslogger
 
   VERSION = "1.5.0"
 
-  attr_reader :level, :ident, :options, :facility, :max_octets
+  attr_reader :level, :ident, :options, :facility, :max_octets, :formatter
 
   MAPPING = {
     Logger::DEBUG => Syslog::LOG_DEBUG,
@@ -46,6 +46,7 @@ class Syslogger
     @facility = facility
     @level = Logger::INFO
     @mutex = Mutex.new
+    @formatter = Logger::Formatter.new
   end
 
   %w{debug info warn error fatal unknown}.each do |logger_method|
@@ -81,8 +82,8 @@ class Syslogger
   #             If both are nil or no block is given, it will use the progname as per the behaviour of both the standard Ruby logger, and the Rails BufferedLogger.
   # +progname+:: optionally, overwrite the program name that appears in the log message.
   def add(severity, message = nil, progname = nil, &block)
-    if message.nil? && block.nil? && !progname.nil? 
-      message, progname = progname, nil 
+    if message.nil? && block.nil? && !progname.nil?
+      message, progname = progname, nil
     end
     progname ||= @ident
 


### PR DESCRIPTION
When using Rails 4 and ActiveSupport::TaggedLogging it raises an exception because Syslogger doesn't have a formatter method, so I'm just using Logger::Formatter.
