### PR TITLE
Race condition fix

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -47,10 +47,10 @@ class Syslogger
     @options = options || (Syslog::LOG_PID | Syslog::LOG_CONS)
     @facility = facility
     @level = Logger::INFO
-    @mutex = Mutex.new
     @formatter = proc do |severity, datetime, progname, msg|
       msg
     end
+    @@mutex = Mutex.new
   end
 
   %w{debug info warn error fatal unknown}.each do |logger_method|
@@ -91,7 +91,7 @@ class Syslogger
     end
     progname ||= @ident
 
-    @mutex.synchronize do
+    @@mutex.synchronize do
       Syslog.open(progname, @options, @facility) do |s|
         s.mask = Syslog::LOG_UPTO(MAPPING[@level])
         communication = clean(message || block && block.call)

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -102,6 +102,26 @@ describe "Syslogger" do
     logger.write "yop"
   end
 
+  it "should allow multiple instances to log at the same time" do
+    logger1 = Syslogger.new("my_app1", Syslog::LOG_PID, Syslog::LOG_USER)
+    logger2 = Syslogger.new("my_app2", Syslog::LOG_PID, Syslog::LOG_USER)
+
+    thread1 = Thread.new do
+      5000.times do |i|
+        logger1.write "logger1"
+      end
+    end
+
+    thread2 = Thread.new do
+      5000.times do |i|
+        logger2.write "logger1"
+      end
+    end
+
+    thread1.join
+    thread2.join
+  end
+
   describe "add" do
     before do
       @logger = Syslogger.new("my_app", Syslog::LOG_PID, Syslog::LOG_USER)


### PR DESCRIPTION
There is a race condition if you have multiple instances of the Syslogger class. In one of our applications we are using one for an event log, and another for the general Rails log (each has it's own syslog tag). Doing this causes exceptions like this to appear randomly in our Sidekiq jobs:

```ruby
RuntimeError:
  syslog already open
```

This is caused by calling `Syslog.open` when it is already open. Although there is a mutex in the Syslogger class to prevent this, if you have multiple instances each one has it's own mutex. In this PR I've simply changed the mutex to a class, rather than an instance variable, which fixes the issue.