### PR TITLE
Both the formatted message and tagging must be cleaned for % escaping…

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -92,8 +92,8 @@ class Syslogger
     end
     progname ||= @ident
     mask = Syslog::LOG_UPTO(MAPPING[@level])
-    communication = clean(message || block && block.call)
-    formatted_communication = formatter.call([severity], Time.now, progname, communication)
+    communication = message || block && block.call
+    formatted_communication = clean(formatter.call([severity], Time.now, progname, communication))
     
     MUTEX.synchronize do
       Syslog.open(progname, @options, @facility) do |s|
@@ -177,7 +177,7 @@ class Syslogger
   def tags_text
     tags = current_tags
     if tags.any?
-      tags.collect { |tag| "[#{tag}] " }.join
+      clean(tags.collect { |tag| "[#{tag}] " }.join) << " "
     end
   end
 


### PR DESCRIPTION
Came across this when using `ActiveSupport::TaggedLogging`.  Only the message was being cleaned for % escaping used by `Syslog#log`.  `TaggedLogging` uses a formatter, which in turned returned a %3D, which was not escaped, causing a `malformed format string - %D` error.

Added cleaning of the formatted message and tags.