### PR TITLE
Expose current_tags as public method [no-merge]

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -5,7 +5,7 @@ require 'thread'
 class Syslogger
 
   VERSION = "1.6.4"
-  
+
   MUTEX = Mutex.new
 
   attr_reader :level, :ident, :options, :facility, :max_octets
@@ -94,7 +94,7 @@ class Syslogger
     mask = Syslog::LOG_UPTO(MAPPING[@level])
     communication = message || block && block.call
     formatted_communication = clean(formatter.call([severity], Time.now, progname, communication))
-    
+
     MUTEX.synchronize do
       Syslog.open(progname, @options, @facility) do |s|
         s.mask = mask
@@ -160,6 +160,10 @@ class Syslogger
     current_tags.clear
   end
 
+  def current_tags
+    Thread.current[:syslogger_tagged_logging_tags] ||= []
+  end
+
   protected
 
   # Borrowed from SyslogLogger.
@@ -179,9 +183,5 @@ class Syslogger
     if tags.any?
       clean(tags.collect { |tag| "[#{tag}] " }.join) << " "
     end
-  end
-
-  def current_tags
-    Thread.current[:syslogger_tagged_logging_tags] ||= []
   end
 end

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -378,4 +378,16 @@ describe "Syslogger" do
     end
   end # describe ":level? methods"
 
+  describe "#push_tags" do
+    before do
+      @logger = Syslogger.new("my_app", Syslog::LOG_PID, Syslog::LOG_USER)
+      @logger.push_tags("tag1")
+      @logger.push_tags("tag2")
+    end
+
+    it "saves tags" do
+      @logger.current_tags.should == ["tag1", "tag2"]
+    end
+  end
+
 end # describe "Syslogger"


### PR DESCRIPTION
`logger.tagged` support was added in the following commit: https://github.com/crohr/syslogger/commit/a43ea7fc65aa061f6d37a65bc436cdd7f88c7016

But with the `current_tags` method being private, myself and others are running into issues when using Syslogger with ActiveJob:

https://github.com/rails/rails/issues/19439

Any reason `current_tags` can't be public?
