### PR TITLE
Update syslogger.rb

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -79,6 +79,10 @@ class Syslogger
   def <<(msg)
     add(Logger::INFO, msg)
   end
+  
+  def puts(msg)
+    add(Logger::INFO, msg)
+  end
 
   # Low level method to add a message.
   # +severity+::  the level of the message. One of Logger::DEBUG, Logger::INFO, Logger::WARN, Logger::ERROR, Logger::FATAL, Logger::UNKNOWN


### PR DESCRIPTION
in phusion_passenger logs are written using 'logger.puts', and this causes an exception when using syslogger. Adding a puts method redirects those messages to syslog
