### PR TITLE
Fixnum type is deprecated

### DIFF
--- a/lib/syslogger.rb
+++ b/lib/syslogger.rb
@@ -126,7 +126,7 @@ class Syslogger
   def level=(level)
     level = Logger.const_get(level.to_s.upcase) if level.is_a?(Symbol)
 
-    unless level.is_a?(Fixnum)
+    unless level.is_a?(Integer)
       raise ArgumentError.new("Invalid logger level `#{level.inspect}`")
     end
 

--- a/spec/syslogger_spec.rb
+++ b/spec/syslogger_spec.rb
@@ -281,7 +281,7 @@ describe "Syslogger" do
         @logger.level.should equal level_value
       end
 
-      it "should allow using Fixnum #{level_value}" do
+      it "should allow using Integer #{level_value}" do
         @logger.level = level_value
         @logger.level.should equal level_value
       end


### PR DESCRIPTION
Fixes https://github.com/crohr/syslogger/issues/41

Not sure if I need to update the gemspect to a new Ruby version for `Integer` type support.