### PR TITLE
Add `syslog` as a dependency

### DIFF
--- a/syslogger.gemspec
+++ b/syslogger.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
+  s.add_dependency 'syslog'
   s.add_development_dependency 'activejob'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'guard-rspec'


### PR DESCRIPTION
Since Ruby 3.3.0, RubyGems and Bundler warn if users require the gems that will become the bundled gems in the future version of Ruby. Please see the "Standard library updates" section for the details. https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`syslogger` uses `syslog`. This fixes the following warning.

```
crohr/syslogger/lib/syslogger.rb:2: warning: syslog was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add syslog to your Gemfile or gemspec.
```